### PR TITLE
Add -execve argument pass to qemu

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -5932,6 +5932,9 @@ static abi_long qemu_execve(char *filename, char *argv[],
         }
     }
 
+	/* Need to store execve argument */
+	offset++;
+
     new_argp = alloca((argc + offset + 1) * sizeof(void *));
 
     /* Copy the original arguments with offset */
@@ -5940,19 +5943,20 @@ static abi_long qemu_execve(char *filename, char *argv[],
     }
 
     new_argp[0] = strdup(qemu_execve_path);
-    new_argp[1] = strdup("-0");
+    new_argp[1] = strdup("-execve"); /* Add execve argument */
+    new_argp[2] = strdup("-0");
     new_argp[offset] = filename;
     new_argp[argc + offset] = NULL;
 
     if (i_name) {
-        new_argp[2] = i_name;
         new_argp[3] = i_name;
+        new_argp[4] = i_name;
 
         if (i_arg) {
-            new_argp[4] = i_arg;
+            new_argp[5] = i_arg;
         }
     } else {
-        new_argp[2] = argv[0];
+        new_argp[3] = argv[0];
     }
 
     return get_errno(execve(qemu_execve_path, new_argp, envp));


### PR DESCRIPTION
I use alpine linux for docker image. But alpine' defult shell is busybox link.
It cannot run your execve , cause it run again 'busybox sh" without QEMU_EXECVE env.
So I add -execve option where invoke command.
It runs good with binfmt without binfmt