### PR TITLE
linux-user: Properly load hashbang scripts

### DIFF
--- a/linux-user/Makefile.objs
+++ b/linux-user/Makefile.objs
@@ -1,5 +1,5 @@
 obj-y = main.o syscall.o strace.o mmap.o signal.o \
-	elfload.o linuxload.o uaccess.o uname.o \
+	elfload.o scriptload.o linuxload.o uaccess.o uname.o \
 	safe-syscall.o $(TARGET_ABI_DIR)/signal.o \
         $(TARGET_ABI_DIR)/cpu_loop.o exit.o fd-trans.o
 

--- a/linux-user/qemu.h
+++ b/linux-user/qemu.h
@@ -201,6 +201,7 @@ int info_is_fdpic(struct image_info *info);
 uint32_t get_elf_eflags(int fd);
 int load_elf_binary(struct linux_binprm *bprm, struct image_info *info);
 int load_flt_binary(struct linux_binprm *bprm, struct image_info *info);
+int load_script_file(const char *filename, struct linux_binprm *bprm);
 
 abi_long memcpy_to_target(abi_ulong dest, const void *src,
                           unsigned long len);

--- a/linux-user/scriptload.c
+++ b/linux-user/scriptload.c
@@ -1,0 +1,84 @@
+/* Script loader.  Based on linux/fs/binfmt_script.c */
+
+#include "qemu/osdep.h"
+
+#include "qemu.h"
+
+struct linux_binprm;
+
+int load_script_file(const char *filename, struct linux_binprm *bprm)
+{
+    int retval, fd;
+    char *i_arg = NULL, *i_name = NULL;
+    char **new_argp;
+    char *cp;
+    char buf[BPRM_BUF_SIZE];
+
+    /* Check if it is a script */
+    fd = open(filename, O_RDONLY);
+    if (fd == -1) {
+        return -ENOEXEC;
+    }
+
+    retval = read(fd, buf, BPRM_BUF_SIZE);
+    if (retval == -1) {
+        close(fd);
+        return -ENOEXEC;
+    }
+
+     /* if we have less than 2 bytes, we can guess it is not executable */
+        if (retval < 2) {
+            close(fd);
+            return -ENOEXEC;
+        }
+
+    close(fd);
+    /* adapted from the kernel
+     * https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/fs/binfmt_script.c
+     */
+    if ((buf[0] == '#') && (buf[1] == '!')) {
+        buf[BPRM_BUF_SIZE - 1] = '\0';
+        cp = strchr(buf, '\n');
+        if (cp == NULL) {
+            cp = buf + BPRM_BUF_SIZE - 1;
+        }
+        *cp = '\0';
+        while (cp > buf) {
+            cp--;
+            if ((*cp == ' ') || (*cp == '\t')) {
+                *cp = '\0';
+            } else {
+                break;
+            }
+        }
+        for (cp = buf + 2; (*cp == ' ') || (*cp == '\t'); cp++) {
+            /* nothing */ ;
+        }
+        if (*cp == '\0') {
+            return -ENOEXEC; /* No interpreter name found */
+        }
+        i_name = cp;
+        i_arg = NULL;
+        for ( ; *cp && (*cp != ' ') && (*cp != '\t'); cp++) {
+            /* nothing */ ;
+        }
+        while ((*cp == ' ') || (*cp == '\t')) {
+            *cp++ = '\0';
+        }
+
+        new_argp = NULL;
+        if (*cp) {
+            i_arg = cp;
+        }
+
+        if (i_arg) {
+            new_argp = alloca(sizeof(void *));
+            new_argp[0] = i_arg;
+        }
+        bprm->argv = new_argp;
+        bprm->filename = i_name;
+    } else {
+        return 1;
+    }
+    return 0;
+}

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -6948,12 +6948,10 @@ static int host_to_target_cpu_mask(const unsigned long *host_mask,
 static abi_long qemu_execve(char *filename, char *argv[],
                   char *envp[])
 {
-    char *i_arg = NULL, *i_name = NULL;
     char **new_argp;
     const char *new_filename;
-    int argc, fd, ret, i, offset = 3;
-    char *cp;
-    char buf[BINPRM_BUF_SIZE];
+    int argc, ret, i, offset = 3;
+    struct linux_binprm *bprm;
 
     /* normal execve case */
     if (qemu_execve_path == NULL || *qemu_execve_path == 0) {
@@ -6966,67 +6964,10 @@ static abi_long qemu_execve(char *filename, char *argv[],
             /* nothing */ ;
         }
 
-        fd = open(filename, O_RDONLY);
-        if (fd == -1) {
-            return get_errno(fd);
-        }
-
-        ret = read(fd, buf, BINPRM_BUF_SIZE);
-        if (ret == -1) {
-            close(fd);
-            return get_errno(ret);
-        }
-
-        /* if we have less than 2 bytes, we can guess it is not executable */
-        if (ret < 2) {
-            close(fd);
-            return -host_to_target_errno(ENOEXEC);
-        }
-
-        close(fd);
-
-        /* adapted from the kernel
-         * https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/fs/binfmt_script.c
-         */
-        if ((buf[0] == '#') && (buf[1] == '!')) {
-            /*
-             * This section does the #! interpretation.
-             * Sorta complicated, but hopefully it will work.  -TYT
-             */
-
-            buf[BINPRM_BUF_SIZE - 1] = '\0';
-            cp = strchr(buf, '\n');
-            if (cp == NULL) {
-                cp = buf + BINPRM_BUF_SIZE - 1;
-            }
-            *cp = '\0';
-            while (cp > buf) {
-                cp--;
-                if ((*cp == ' ') || (*cp == '\t')) {
-                    *cp = '\0';
-                } else {
-                    break;
-                }
-            }
-            for (cp = buf + 2; (*cp == ' ') || (*cp == '\t'); cp++) {
-                /* nothing */ ;
-            }
-            if (*cp == '\0') {
-                return -ENOEXEC; /* No interpreter name found */
-            }
-            i_name = cp;
-            i_arg = NULL;
-            for ( ; *cp && (*cp != ' ') && (*cp != '\t'); cp++) {
-                /* nothing */ ;
-            }
-            while ((*cp == ' ') || (*cp == '\t')) {
-                *cp++ = '\0';
-            }
-            if (*cp) {
-                i_arg = cp;
-            }
-
-            if (i_arg) {
+        bprm = alloca(sizeof(struct linux_binprm));
+        ret = load_script_file(filename, bprm);
+        if (ret==0) {
+            if (bprm->argv != NULL) {
                 offset = 5;
             } else {
                 offset = 4;
@@ -7049,12 +6990,12 @@ static abi_long qemu_execve(char *filename, char *argv[],
         new_argp[offset] = filename;
         new_argp[argc + offset] = NULL;
 
-        if (i_name) {
-            new_argp[3] = i_name;
-            new_argp[4] = i_name;
+        if (ret==0) {
+            new_argp[3] = bprm->filename;
+            new_argp[4] = bprm->filename;
 
-            if (i_arg) {
-                new_argp[5] = i_arg;
+            if (bprm->argv != NULL) {
+                new_argp[5] = bprm->argv[0];
             }
         } else {
             new_argp[3] = argv[0];


### PR DESCRIPTION
Add loader that parses hashbang scripts in loader_exec() in order to make QEMU works with scripts as QEMU only accepts ELF or flat binary.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>