### PR TITLE
Fix wrong errno in load_script_file and properly handle them in syscall

### DIFF
--- a/linux-user/scriptload.c
+++ b/linux-user/scriptload.c
@@ -17,13 +17,13 @@ int load_script_file(const char *filename, struct linux_binprm *bprm)
     /* Check if it is a script */
     fd = open(filename, O_RDONLY);
     if (fd == -1) {
-        return -ENOEXEC;
+        return fd;
     }
 
     retval = read(fd, buf, BPRM_BUF_SIZE);
     if (retval == -1) {
         close(fd);
-        return -ENOEXEC;
+        return retval;
     }
 
      /* if we have less than 2 bytes, we can guess it is not executable */

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -6966,7 +6966,16 @@ static abi_long qemu_execve(char *filename, char *argv[],
 
         bprm = alloca(sizeof(struct linux_binprm));
         ret = load_script_file(filename, bprm);
-        if (ret==0) {
+
+        if (ret < 0) {
+          if (ret == -1) {
+            return get_errno(ret);
+          } else {
+            return -host_to_target_errno(ENOEXEC);
+          }
+        }
+
+        if (ret == 0) {
             if (bprm->argv != NULL) {
                 offset = 5;
             } else {


### PR DESCRIPTION
load_script_file() only returns one errno (-ENOEXEC) which is
wrong. Also in qemu_execve(), the errno from load_script_file() is
ignored so it proceeds to execve into the file even the file does not
exist or not an executable...

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>